### PR TITLE
fix(rtc): use invitation roomID when requesting caller token

### DIFF
--- a/src/pages/rtc/index.vue
+++ b/src/pages/rtc/index.vue
@@ -20,7 +20,6 @@ import emitter from "@/utils/events";
 import { feedbackToast } from "@/utils/common";
 import { CustomType } from "@/constants/enum";
 import { getRtcConnectData } from "@/api/im";
-import { v4 as uuidV4 } from "uuid";
 
 type RtcProps = {
   inviteData: InviteData;
@@ -86,8 +85,12 @@ const checkTimeout = () => {
 const tryInvite = async () => {
   if (!isRecv.value) {
     try {
+      const roomID = props.inviteData.invitation?.roomID;
+      if (!roomID) {
+        throw new Error("RTC roomID is missing");
+      }
       const { data } = await getRtcConnectData(
-        uuidV4(),
+        roomID,
         userStore.selfInfo.userID
       );
       config.serverUrl = data.serverUrl;


### PR DESCRIPTION
## 🅰 Please add the issue ID after "Fixes #"

Fixes #46 

This PR fixes an RTC room mismatch during call setup.

Previously, the caller requested a token with a newly generated room ID, while the callee joined using the invitation room ID. This caused both participants to enter different rooms, resulting in connected calls with no audio/video.

Now, the caller uses the invitation room ID when requesting the RTC token, ensuring both sides join the same room and media flows correctly.